### PR TITLE
fixed missing quote

### DIFF
--- a/data/modifications.txt
+++ b/data/modifications.txt
@@ -51,7 +51,7 @@ shipyard "human plugins"
 	"Mockingjay"
 	"Skein D"
 	
-outfitter "human plugins
+outfitter "human plugins"
 	"Espionage Module"
 	"Cryogenics Pod"
 	"AI Module"


### PR DESCRIPTION
An outfitter name is missing a closing quote.